### PR TITLE
Add ability to rescan IPs

### DIFF
--- a/custom_components/localtuya_rc/config_flow.py
+++ b/custom_components/localtuya_rc/config_flow.py
@@ -254,6 +254,103 @@ class LocalTuyaIRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 
+    async def async_step_reconfigure(self, user_input=None):
+        """Handle reconfiguration of the device (e.g. IP change)."""
+        entry = self._get_reconfigure_entry()
+        self.config = dict(entry.data)
+        return self.async_show_menu(
+            step_id="reconfigure",
+            menu_options=["reconfigure_scan", "reconfigure_manual"])
+
+    async def async_step_reconfigure_scan(self, user_input=None):
+        """Scan network to find the device at a new IP."""
+        entry = self._get_reconfigure_entry()
+        config = dict(entry.data)
+        dev_id = config[CONF_DEVICE_ID]
+        local_key = config[CONF_LOCAL_KEY]
+        protocol_version = config[CONF_PROTOCOL_VERSION]
+
+        try:
+            scan_devices = await self.hass.async_add_executor_job(tinytuya.deviceScan)
+        except Exception as e:
+            _LOGGER.error("Scan error: %s", e, exc_info=True)
+            return self.async_show_form(
+                step_id="reconfigure_scan",
+                errors={"base": "unknown"},
+                data_schema=vol.Schema({})
+            )
+
+        # Find our device by ID
+        new_ip = None
+        for ip, device in scan_devices.items():
+            if device.get("gwId") == dev_id:
+                new_ip = ip
+                break
+
+        if not new_ip:
+            return self.async_show_form(
+                step_id="reconfigure_scan",
+                errors={"base": "tuya_not_found"},
+                data_schema=vol.Schema({})
+            )
+
+        # Test connection at the new IP
+        try:
+            device, status = await self.hass.async_add_executor_job(
+                self._test_connection, dev_id, new_ip, local_key, float(protocol_version))
+        except Exception as e:
+            _LOGGER.error("Connection test error at %s: %s", new_ip, e, exc_info=True)
+            return self.async_show_form(
+                step_id="reconfigure_scan",
+                errors={"base": "cannot_connect"},
+                data_schema=vol.Schema({})
+            )
+
+        if "Error" in status:
+            return self.async_show_form(
+                step_id="reconfigure_scan",
+                errors={"base": "cannot_connect"},
+                data_schema=vol.Schema({})
+            )
+
+        config[CONF_HOST] = new_ip
+        return self.async_update_reload_and_abort(entry, data=config, reason="reconfigure_successful")
+
+    async def async_step_reconfigure_manual(self, user_input=None, errors={}):
+        """Allow user to manually enter a new IP address."""
+        entry = self._get_reconfigure_entry()
+        config = dict(entry.data)
+
+        if user_input is not None:
+            new_ip = user_input[CONF_HOST]
+            dev_id = config[CONF_DEVICE_ID]
+            local_key = config[CONF_LOCAL_KEY]
+            protocol_version = config[CONF_PROTOCOL_VERSION]
+
+            # Test connection at the new IP
+            try:
+                device, status = await self.hass.async_add_executor_job(
+                    self._test_connection, dev_id, new_ip, local_key, float(protocol_version))
+            except Exception as e:
+                _LOGGER.error("Connection test error at %s: %s", new_ip, e, exc_info=True)
+                return await self.async_step_reconfigure_manual(errors={"base": "cannot_connect"})
+
+            if "Error" in status:
+                return await self.async_step_reconfigure_manual(errors={"base": "cannot_connect"})
+
+            config[CONF_HOST] = new_ip
+            return self.async_update_reload_and_abort(entry, data=config, reason="reconfigure_successful")
+
+        schema = vol.Schema({
+            vol.Required(CONF_HOST, default=config[CONF_HOST]): cv.string,
+        })
+        return self.async_show_form(
+            step_id="reconfigure_manual",
+            errors=errors,
+            data_schema=schema
+        )
+
+
 class LocalTuyaIROptionsFlow(config_entries.OptionsFlow):
     """Options flow for LocalTuyaIR Remote Control."""
     

--- a/custom_components/localtuya_rc/config_flow.py
+++ b/custom_components/localtuya_rc/config_flow.py
@@ -329,7 +329,7 @@ class LocalTuyaIRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             # Test connection at the new IP
             try:
-                device, status = await self.hass.async_add_executor_job(
+                _, status = await self.hass.async_add_executor_job(
                     self._test_connection, dev_id, new_ip, local_key, float(protocol_version))
             except Exception as e:
                 _LOGGER.error("Connection test error at %s: %s", new_ip, e, exc_info=True)

--- a/custom_components/localtuya_rc/config_flow.py
+++ b/custom_components/localtuya_rc/config_flow.py
@@ -282,8 +282,8 @@ class LocalTuyaIRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Find our device by ID
         new_ip = None
-        for ip, device in scan_devices.items():
-            if device.get("gwId") == dev_id:
+        for ip, found_device in scan_devices.items():
+            if found_device.get("gwId") == dev_id:
                 new_ip = ip
                 break
 

--- a/custom_components/localtuya_rc/translations/en.json
+++ b/custom_components/localtuya_rc/translations/en.json
@@ -3,7 +3,8 @@
     "config": {
         "abort": {
             "already_configured": "Error: integration for this device is already configured.",
-            "unknown": "Unknown error, please check logs."
+            "unknown": "Unknown error, please check logs.",
+            "reconfigure_successful": "Device reconfigured successfully."
         },
         "error": {
             "cannot_connect": "Cannot connect to the device. Verify that address, device id, local key and protocol version are correct.",
@@ -70,6 +71,25 @@
                     "local_key": "Local key",
                     "protocol_version": "Protocol version (usually 3.3 or 3.4)",
                     "persistent_connection": "Persistent connection (faster but can be unstable)"
+                }
+            },
+            "reconfigure": {
+                "title": "Update device connection",
+                "description": "The device IP address may have changed. Choose how to update it.",
+                "menu_options": {
+                    "reconfigure_scan": "Scan the network for the device",
+                    "reconfigure_manual": "Enter a new IP address manually"
+                }
+            },
+            "reconfigure_scan": {
+                "title": "Network scan",
+                "description": "Scanning for the device on the network. If the device was not found, check that it is online and connected to the same network, then submit to retry."
+            },
+            "reconfigure_manual": {
+                "title": "Enter new IP address",
+                "description": "Enter the new IP address for the device. The connection will be tested before saving.",
+                "data": {
+                    "host": "Device IP address"
                 }
             }
         }


### PR DESCRIPTION
After seeing a few instances of things like https://github.com/ClusterM/localtuya_rc/issues/18#issuecomment-3198035573 and https://github.com/ClusterM/localtuya_rc/issues/29#issuecomment-3975154812, I added a reconfigure step which allows users to update the IP address of a connected device after they've already gone through the configuration step