### PR TITLE
fix(remote): recover unavailable IR bridges

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,20 @@
+name: Pytest
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install pytest==8.3.5
+      - run: python -m pytest

--- a/custom_components/localtuya_rc/manifest.json
+++ b/custom_components/localtuya_rc/manifest.json
@@ -9,6 +9,6 @@
   "documentation": "https://github.com/ClusterM/localtuya_rc/blob/master/README.md",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ClusterM/localtuya_rc/issues",
-  "requirements": ["tinytuya>=1.18.0"],
+  "requirements": ["tinytuya>=1.20.0"],
   "version": "2.0.0"
 }

--- a/custom_components/localtuya_rc/remote.py
+++ b/custom_components/localtuya_rc/remote.py
@@ -4,7 +4,7 @@ import asyncio
 import struct
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
-from tinytuya import Contrib
+from tinytuya import Contrib, ERR_TIMEOUT
 from tinytuya.Contrib import RFRemoteControlDevice
 import threading
 
@@ -61,6 +61,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Serialize this device's polls and actions before they enter HA's executor.
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(hass, entry, async_add_entities, discovery_info=None):
@@ -358,6 +361,22 @@ class TuyaRC(RemoteEntity):
         try:
             self._init()
             status = self._device.status()
+            # tinytuya documents that an IR bridge can accept a connection after
+            # reboot but ignore status() until it receives a command. study_end()
+            # is its non-transmitting wake probe for the detected control type.
+            if self._device.control_type and (
+                status is None
+                or (
+                    isinstance(status, dict)
+                    and status.get("Err") == str(ERR_TIMEOUT)
+                )
+            ):
+                _LOGGER.debug(
+                    "Waking IR device %s after an unresponsive status request",
+                    self._dev_id,
+                )
+                self._device.study_end()
+                status = self._device.status()
             _LOGGER.debug(f"Device status: {status}")
             self._available = bool(status) and "Error" not in status
             if not self._available:

--- a/custom_components/localtuya_rc/remote.py
+++ b/custom_components/localtuya_rc/remote.py
@@ -62,7 +62,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 _LOGGER = logging.getLogger(__name__)
 
-# Serialize this device's polls and actions before they enter HA's executor.
+# Serialize platform update (polling) calls; send/learn actions are guarded by the instance lock.
 PARALLEL_UPDATES = 1
 
 
@@ -364,12 +364,13 @@ class TuyaRC(RemoteEntity):
             # tinytuya documents that an IR bridge can accept a connection after
             # reboot but ignore status() until it receives a command. study_end()
             # is its non-transmitting wake probe for the detected control type.
-            if self._device.control_type and (
-                status is None
-                or (
-                    isinstance(status, dict)
-                    and status.get("Err") == str(ERR_TIMEOUT)
-                )
+if self._device.control_type and (
+    status is None
+    or (
+        isinstance(status, dict)
+        and str(status.get("Err", "")).strip() == str(ERR_TIMEOUT)
+    )
+):
             ):
                 _LOGGER.debug(
                     "Waking IR device %s after an unresponsive status request",

--- a/custom_components/localtuya_rc/remote.py
+++ b/custom_components/localtuya_rc/remote.py
@@ -62,7 +62,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 _LOGGER = logging.getLogger(__name__)
 
-# Serialize platform update (polling) calls; send/learn actions are guarded by the instance lock.
+# Serialize Home Assistant polls and actions before executor work; the instance
+# lock protects TinyTuya I/O.
 PARALLEL_UPDATES = 1
 
 
@@ -364,13 +365,12 @@ class TuyaRC(RemoteEntity):
             # tinytuya documents that an IR bridge can accept a connection after
             # reboot but ignore status() until it receives a command. study_end()
             # is its non-transmitting wake probe for the detected control type.
-if self._device.control_type and (
-    status is None
-    or (
-        isinstance(status, dict)
-        and str(status.get("Err", "")).strip() == str(ERR_TIMEOUT)
-    )
-):
+            if self._device.control_type and (
+                status is None
+                or (
+                    isinstance(status, dict)
+                    and str(status.get("Err", "")).strip() == str(ERR_TIMEOUT)
+                )
             ):
                 _LOGGER.debug(
                     "Waking IR device %s after an unresponsive status request",

--- a/tests/test_midea.py
+++ b/tests/test_midea.py
@@ -8,7 +8,7 @@ import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
-PKG_DIR = ROOT / "custom_components" / "flipper_rc"
+PKG_DIR = ROOT / "custom_components" / "localtuya_rc"
 
 # Load `pulse` and `manchester` as top-level modules first so `rc_encoder`
 # can `import pulse` / `import manchester` from its fallback path.

--- a/tests/test_remote_recovery.py
+++ b/tests/test_remote_recovery.py
@@ -91,8 +91,10 @@ def remote_module(monkeypatch):
     _install_module(monkeypatch, "homeassistant.helpers.storage", Store=object)
 
     contrib = types.SimpleNamespace(IRRemoteControlDevice=object)
-tinytuya = _install_module(monkeypatch, "tinytuya", Contrib=contrib, ERR_TIMEOUT=902)
-tinytuya.__path__ = []
+    tinytuya = _install_module(
+        monkeypatch, "tinytuya", Contrib=contrib, ERR_TIMEOUT=902
+    )
+    tinytuya.__path__ = []
     _install_module(
         monkeypatch,
         "tinytuya.Contrib",
@@ -173,8 +175,8 @@ def _make_remote(remote_module, statuses, control_type=1, study_end_error=None):
 
 @pytest.mark.parametrize(
     "initial_status",
-    [_status_error("902"), None],
-    ids=["timeout", "empty-response"],
+    [_status_error("902"), _status_error(902), None],
+    ids=["string-timeout", "numeric-timeout", "empty-response"],
 )
 def test_reachable_silent_device_wakes_after_study_end(
     remote_module, initial_status

--- a/tests/test_remote_recovery.py
+++ b/tests/test_remote_recovery.py
@@ -91,7 +91,8 @@ def remote_module(monkeypatch):
     _install_module(monkeypatch, "homeassistant.helpers.storage", Store=object)
 
     contrib = types.SimpleNamespace(IRRemoteControlDevice=object)
-    _install_module(monkeypatch, "tinytuya", Contrib=contrib, ERR_TIMEOUT=902)
+tinytuya = _install_module(monkeypatch, "tinytuya", Contrib=contrib, ERR_TIMEOUT=902)
+tinytuya.__path__ = []
     _install_module(
         monkeypatch,
         "tinytuya.Contrib",
@@ -175,11 +176,10 @@ def _make_remote(remote_module, statuses, control_type=1, study_end_error=None):
     [_status_error("902"), None],
     ids=["timeout", "empty-response"],
 )
-def test_reachable_silent_device_wakes_after_study_exit(
+def test_reachable_silent_device_wakes_after_study_end(
     remote_module, initial_status
 ):
-    """A reachable bridge that ignores status wakes after study_exit."""
-
+    """A reachable bridge that ignores status wakes after study_end."""
     remote, device_class = _make_remote(
         remote_module, [initial_status, {"dps": {}}]
     )

--- a/tests/test_remote_recovery.py
+++ b/tests/test_remote_recovery.py
@@ -1,0 +1,286 @@
+"""Regression tests for unavailable IR bridge recovery."""
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REMOTE_PATH = ROOT / "custom_components" / "localtuya_rc" / "remote.py"
+MANIFEST_PATH = ROOT / "custom_components" / "localtuya_rc" / "manifest.json"
+PACKAGE_NAME = "localtuya_rc_test"
+
+
+class _PlatformSchema:
+    def extend(self, _schema):
+        return self
+
+
+def _install_module(monkeypatch, name, **attributes):
+    module = types.ModuleType(name)
+    module.__dict__.update(attributes)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+@pytest.fixture
+def remote_module(monkeypatch):
+    # WHY: this project has no Home Assistant test harness.
+    # WHEN: remove this when one is added.
+    # REAL: use Home Assistant's EntityPlatform and service-call fixtures.
+    homeassistant = _install_module(monkeypatch, "homeassistant")
+    homeassistant.__path__ = []
+    helpers = _install_module(monkeypatch, "homeassistant.helpers")
+    helpers.__path__ = []
+    components = _install_module(monkeypatch, "homeassistant.components")
+    components.__path__ = []
+
+    _install_module(
+        monkeypatch,
+        "voluptuous",
+        Required=lambda value, **_kwargs: value,
+        In=lambda values: values,
+    )
+    _install_module(
+        monkeypatch,
+        "homeassistant.helpers.config_validation",
+        string=str,
+        boolean=bool,
+    )
+    _install_module(
+        monkeypatch,
+        "homeassistant.const",
+        CONF_NAME="name",
+        CONF_HOST="host",
+        CONF_DEVICE_ID="device_id",
+    )
+    _install_module(monkeypatch, "homeassistant.helpers.entity", DeviceInfo=dict)
+
+    class HomeAssistantError(Exception):
+        """Minimal Home Assistant error type for the unit under test."""
+
+    _install_module(
+        monkeypatch,
+        "homeassistant.exceptions",
+        HomeAssistantError=HomeAssistantError,
+    )
+    _install_module(
+        monkeypatch,
+        "homeassistant.components.persistent_notification",
+        async_create=lambda *_args, **_kwargs: None,
+    )
+    _install_module(
+        monkeypatch,
+        "homeassistant.components.remote",
+        ATTR_COMMAND_TYPE="command_type",
+        ATTR_TIMEOUT="timeout",
+        ATTR_ALTERNATIVE="alternative",
+        ATTR_COMMAND="command",
+        ATTR_DEVICE="device",
+        ATTR_DELAY_SECS="delay_secs",
+        ATTR_NUM_REPEATS="num_repeats",
+        ATTR_HOLD_SECS="hold_secs",
+        PLATFORM_SCHEMA=_PlatformSchema(),
+        RemoteEntity=type("RemoteEntity", (), {}),
+        RemoteEntityFeature=types.SimpleNamespace(LEARN_COMMAND=1, DELETE_COMMAND=2),
+    )
+    _install_module(monkeypatch, "homeassistant.helpers.storage", Store=object)
+
+    contrib = types.SimpleNamespace(IRRemoteControlDevice=object)
+    _install_module(monkeypatch, "tinytuya", Contrib=contrib, ERR_TIMEOUT=902)
+    _install_module(
+        monkeypatch,
+        "tinytuya.Contrib",
+        RFRemoteControlDevice=types.SimpleNamespace(RFRemoteControlDevice=object),
+    )
+
+    package = _install_module(monkeypatch, PACKAGE_NAME)
+    package.__path__ = []
+    _install_module(
+        monkeypatch,
+        f"{PACKAGE_NAME}.const",
+        DOMAIN="localtuya_rc",
+        DEFAULT_FRIENDLY_NAME="Tuya IR Remote Control",
+        CONF_LOCAL_KEY="local_key",
+        CONF_PROTOCOL_VERSION="protocol_version",
+        CONF_CONTROL_TYPE="control_type",
+        CONF_CLOUD_INFO="cloud_info",
+        CONF_PERSISTENT_CONNECTION="persistent_connection",
+        CODE_STORAGE_VERSION=1,
+        CODE_STORAGE_CODES="localtuya_rc_codes",
+        NOTIFICATION_TITLE="Tuya IR Remote Control",
+        DEFAULT_PERSISTENT_CONNECTION=False,
+    )
+    _install_module(
+        monkeypatch,
+        f"{PACKAGE_NAME}.rc_encoder",
+        rc_auto_encode=lambda value: value,
+        rc_auto_decode=lambda value, **_kwargs: value,
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        f"{PACKAGE_NAME}.remote", REMOTE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _status_error(code):
+    return {"Error": "Device error", "Err": code, "Payload": None}
+
+
+def _make_remote(remote_module, statuses, control_type=1, study_end_error=None):
+    class Device:
+        instance = None
+
+        def __init__(self, **_kwargs):
+            self.control_type = control_type
+            self.status_calls = 0
+            self.study_end_calls = 0
+            self.closed = False
+            self._statuses = iter(statuses)
+            Device.instance = self
+
+        def status(self):
+            self.status_calls += 1
+            return next(self._statuses)
+
+        def study_end(self):
+            self.study_end_calls += 1
+            if study_end_error:
+                raise study_end_error
+
+        def close(self):
+            self.closed = True
+
+    remote_module.Contrib.IRRemoteControlDevice = Device
+    return remote_module.TuyaRC(
+        "Test",
+        "device-id",
+        "127.0.0.1",
+        "local-key",
+        "3.3",
+        control_type=control_type,
+    ), Device
+
+
+@pytest.mark.parametrize(
+    "initial_status",
+    [_status_error("902"), None],
+    ids=["timeout", "empty-response"],
+)
+def test_reachable_silent_device_wakes_after_study_exit(
+    remote_module, initial_status
+):
+    """A reachable bridge that ignores status wakes after study_exit."""
+
+    remote, device_class = _make_remote(
+        remote_module, [initial_status, {"dps": {}}]
+    )
+    remote._update_availibility_locked()
+
+    assert remote.available is True
+    assert device_class.instance.status_calls == 2
+    assert device_class.instance.study_end_calls == 1
+    assert device_class.instance.closed is False
+
+
+@pytest.mark.parametrize(
+    "retry_status",
+    [None, _status_error("902")],
+    ids=["empty-response", "timeout"],
+)
+def test_silent_device_remains_unavailable_after_one_wake_retry(
+    remote_module, retry_status
+):
+    """A wake gets one retry, then deinitializes if the bridge stays silent."""
+
+    remote, device_class = _make_remote(remote_module, [None, retry_status])
+    remote._update_availibility_locked()
+
+    assert remote.available is False
+    assert device_class.instance.status_calls == 2
+    assert device_class.instance.study_end_calls == 1
+    assert device_class.instance.closed is True
+
+
+@pytest.mark.parametrize("error_code", ["901", "904", "905", "914"])
+def test_nonrecoverable_status_errors_do_not_send_wake_command(
+    remote_module, error_code
+):
+    """Unreachable or invalid devices must not receive a recovery command."""
+
+    remote, device_class = _make_remote(
+        remote_module, [_status_error(error_code)]
+    )
+    remote._update_availibility_locked()
+
+    assert remote.available is False
+    assert device_class.instance.status_calls == 1
+    assert device_class.instance.study_end_calls == 0
+    assert device_class.instance.closed is True
+
+
+def test_unknown_control_type_does_not_send_wake_command(remote_module):
+    """Auto-detection failures must not call study_end without a control type."""
+
+    remote, device_class = _make_remote(
+        remote_module, [_status_error("902")], control_type=0
+    )
+    remote._update_availibility_locked()
+
+    assert remote.available is False
+    assert device_class.instance.study_end_calls == 0
+    assert device_class.instance.closed is True
+
+
+def test_failed_wake_deinitializes_device(remote_module):
+    """A failed wake attempt must retain the existing clean recovery path."""
+
+    remote, device_class = _make_remote(
+        remote_module,
+        [_status_error("902")],
+        study_end_error=RuntimeError("wake failed"),
+    )
+    remote._update_availibility_locked()
+
+    assert remote.available is False
+    assert device_class.instance.study_end_calls == 1
+    assert device_class.instance.closed is True
+
+
+def test_available_device_does_not_receive_wake_command(remote_module):
+    """Healthy status responses must remain a single request."""
+
+    remote, device_class = _make_remote(remote_module, [{"dps": {}}])
+    remote._update_availibility_locked()
+
+    assert remote.available is True
+    assert device_class.instance.status_calls == 1
+    assert device_class.instance.study_end_calls == 0
+
+
+def test_platform_declares_single_parallel_request(remote_module):
+    """Home Assistant must serialize this remote's polls and actions."""
+
+    assert remote_module.PARALLEL_UPDATES == 1
+
+
+def test_requires_tinytuya_timeout_error_support():
+    """The recovery probe requires tinytuya's distinct timeout response."""
+
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    requirement = next(
+        item
+        for item in manifest["requirements"]
+        if item.startswith("tinytuya>=")
+    )
+    version = tuple(int(part) for part in requirement.split(">=", 1)[1].split("."))
+
+    assert version >= (1, 20, 0)


### PR DESCRIPTION
TinyTuya's IR code notes that a bridge can stay silent to `status()` after a restart until it receives a command. localtuya_rc caches `control_type`, so a reinitialized remote skips the detection sequence that sends `study_exit`.

Wake that reachable-but-silent bridge with `study_end()`, then retry status once. Offline, invalid-key, and malformed-response paths retain the existing cleanup. `PARALLEL_UPDATES = 1` also prevents availability polling and remote actions from piling up in Home Assistant's executor while the device is busy.

This requires TinyTuya 1.20+, which reports the response timeout separately from key/version failures. The change includes regression coverage, restores the Midea test import, and runs pytest in CI.