### PR TITLE
fix(remote): also wake IR bridge on ERR_JSON 900 (empty DP cache)

### DIFF
--- a/custom_components/localtuya_rc/remote.py
+++ b/custom_components/localtuya_rc/remote.py
@@ -4,7 +4,7 @@ import asyncio
 import struct
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
-from tinytuya import Contrib, ERR_TIMEOUT
+from tinytuya import Contrib, ERR_JSON, ERR_TIMEOUT
 from tinytuya.Contrib import RFRemoteControlDevice
 import threading
 
@@ -363,13 +363,17 @@ class TuyaRC(RemoteEntity):
             self._init()
             status = self._device.status()
             # tinytuya documents that an IR bridge can accept a connection after
-            # reboot but ignore status() until it receives a command. study_end()
-            # is its non-transmitting wake probe for the detected control type.
+            # reboot but ignore status() until it receives a command. A power-
+            # cycled bridge answers status() with ERR_JSON 900 ("json obj data
+            # unvalid") — its DP cache is empty until a SET repopulates it — as
+            # well as the ERR_TIMEOUT case. study_end() is its non-transmitting
+            # wake probe for the detected control type; retry status() once after.
             if self._device.control_type and (
                 status is None
                 or (
                     isinstance(status, dict)
-                    and str(status.get("Err", "")).strip() == str(ERR_TIMEOUT)
+                    and str(status.get("Err", "")).strip()
+                    in (str(ERR_JSON), str(ERR_TIMEOUT))
                 )
             ):
                 _LOGGER.debug(

--- a/tests/test_remote_recovery.py
+++ b/tests/test_remote_recovery.py
@@ -92,7 +92,7 @@ def remote_module(monkeypatch):
 
     contrib = types.SimpleNamespace(IRRemoteControlDevice=object)
     tinytuya = _install_module(
-        monkeypatch, "tinytuya", Contrib=contrib, ERR_TIMEOUT=902
+        monkeypatch, "tinytuya", Contrib=contrib, ERR_JSON=900, ERR_TIMEOUT=902
     )
     tinytuya.__path__ = []
     _install_module(
@@ -175,8 +175,20 @@ def _make_remote(remote_module, statuses, control_type=1, study_end_error=None):
 
 @pytest.mark.parametrize(
     "initial_status",
-    [_status_error("902"), _status_error(902), None],
-    ids=["string-timeout", "numeric-timeout", "empty-response"],
+    [
+        _status_error("902"),
+        _status_error(902),
+        _status_error("900"),
+        _status_error(900),
+        None,
+    ],
+    ids=[
+        "string-timeout",
+        "numeric-timeout",
+        "string-json",
+        "numeric-json",
+        "empty-response",
+    ],
 )
 def test_reachable_silent_device_wakes_after_study_end(
     remote_module, initial_status
@@ -195,8 +207,8 @@ def test_reachable_silent_device_wakes_after_study_end(
 
 @pytest.mark.parametrize(
     "retry_status",
-    [None, _status_error("902")],
-    ids=["empty-response", "timeout"],
+    [None, _status_error("902"), _status_error("900")],
+    ids=["empty-response", "timeout", "json-error"],
 )
 def test_silent_device_remains_unavailable_after_one_wake_retry(
     remote_module, retry_status


### PR DESCRIPTION
## Problem

#36 added a `study_end()` wake probe that revives an IR bridge which accepts a connection after a restart but then ignores `status()`. Its trigger only matches `ERR_TIMEOUT` (902):

```python
and str(status.get("Err", "")).strip() == str(ERR_TIMEOUT)
```

In practice a mains-cycled Tuya IR hub much more often answers `status()` with **`ERR_JSON` 900 — `"json obj data unvalid"`**. This isn't a key/auth failure: the frame decrypts and `cJSON_Parse()` succeeds, but the device's object-DP cache is empty after losing power, so a bare `DP_QUERY` has nothing to serialize and is rejected until a `SET` repopulates it. Because 900 isn't in the wake condition, the bridge stays `unavailable` and only a full Home Assistant restart recovers it — the symptom reported in #30.

## Fix

Widen the existing wake condition to also fire on `ERR_JSON`. The recovery path is unchanged — the same non-transmitting `study_end()` (a DP write, so no IR is emitted) repopulates the cache and the single `status()` retry then succeeds.

## Testing

Verified on a LARKKEY UFO-R1 (`control_type` 2, protocol 3.3, firmware 2.1.4) with the equivalent condition applied:

- **Before:** after cycling mains, every poll logged `Err 900 "json obj data unvalid"` and the entity stayed `unavailable` until a Core restart.
- **After:** recovers within a single poll — the hub returns `Err 905` while still booting (correctly not probed), then `Err 900` once reachable, at which point `study_end()` + the `status()` retry succeed (~180 ms).
- `study_end()` emits no IR — the unit does not actuate when woken.

Closes #30.
