### PR TITLE
Bugfix unkown error cloud_info not found

### DIFF
--- a/custom_components/localtuya_rc/config_flow.py
+++ b/custom_components/localtuya_rc/config_flow.py
@@ -121,7 +121,7 @@ class LocalTuyaIRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             devices = [device for device in self.cloud_devices if device['id'] == id]
             self.config[CONF_NAME] = devices[0]['name']
             self.config[CONF_LOCAL_KEY] = devices[0]['key']
-            self.cloud_info = devices[0] 
+            self.cloud_info = devices[0].copy()
             return await self.async_step_config()
         device_list = [f"{device['name']} ({device['id']})" for device in self.cloud_devices]
         schema = vol.Schema(

--- a/custom_components/localtuya_rc/config_flow.py
+++ b/custom_components/localtuya_rc/config_flow.py
@@ -121,6 +121,7 @@ class LocalTuyaIRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             devices = [device for device in self.cloud_devices if device['id'] == id]
             self.config[CONF_NAME] = devices[0]['name']
             self.config[CONF_LOCAL_KEY] = devices[0]['key']
+            self.cloud_info = devices[0] 
             return await self.async_step_config()
         device_list = [f"{device['name']} ({device['id']})" for device in self.cloud_devices]
         schema = vol.Schema(


### PR DESCRIPTION
**Problem**

When the user chooses the following configuration path:

Cloud API
→ Enter IP manually
→ Configure device

the config flow populates the device name and local key from self.cloud_devices, but never initializes self.cloud_info.

Later, in `async_step_config()`, the code assumes that self.cloud_info always exists:

```
if self.cloud and 'key' in self.cloud_info:
    del self.cloud_info['key']
```

Since self.cloud_info was never created in the manual IP path, Home Assistant raises:

AttributeError: 'LocalTuyaIRConfigFlow' object has no attribute 'cloud_info'

This prevents the configuration from completing successfully.

**Cause**

The scan-based configuration flow correctly initializes self.cloud_info after matching the discovered device with the cloud device list.

However, the manual IP flow performs the same device lookup but only copies the device name and local key, omitting the initialization of self.cloud_info.

As a result, the two configuration paths leave the internal state in different conditions, even though they should provide the same information to the final configuration step.

**Solution**

Initialize self.cloud_info in `async_step_ask_ip()` immediately after retrieving the matching device from self.cloud_devices.

This makes both configuration paths behave consistently and prevents the AttributeError during the final configuration step.

The change is minimal, has no impact on the scan workflow, and only fixes the missing state initialization in the manual IP workflow.