### PR TITLE
Expose Tuya IR hub as an infrared adapter emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ data:
 ```
 
 
+### Infrared adapter entity (for LG Infrared, Samsung Infrared, etc.)
+
+On Home Assistant Core 2026.4 and later, this integration also registers an `infrared.*` entity for your Tuya IR hub, implementing Home Assistant's newer [Infrared](https://www.home-assistant.io/integrations/infrared/) building-block platform. This is separate from, and in addition to, the `remote.*` entity described above.
+
+Brand-specific device integrations built on this newer architecture (e.g. "LG Infrared", "Samsung Infrared") ask you to pick "the emitter from your infrared remote adapter" during setup — they only recognize entities from this `infrared` platform, not arbitrary `remote.*` entities. With this integration's `infrared.*` entity, your Tuya IR hub becomes selectable there, so you can use those integrations' brand-specific codes instead of maintaining your own learned-code tables via `remote.learn_command`.
+
+This entity has no services of its own — it's a plumbing entity that other integrations send commands through. Its "last command sent" timestamp updates automatically as those integrations use it, and its availability follows the `remote.*` entity above, since both share the same connection to the device.
+
+On older Home Assistant Core versions (before 2026.4, which introduced this platform), only the `remote.*` entity is created; this is detected automatically and requires no configuration.
+
 ## IR Code Formatting
 
 When defining IR commands for the Tuya IR remote emulator in Home Assistant, each code is represented as a single string. This string encodes the precise details of the IR command you want to send—either as a sequence of low-level raw timing values or by referencing a known IR protocol with corresponding parameters.

--- a/custom_components/localtuya_rc/__init__.py
+++ b/custom_components/localtuya_rc/__init__.py
@@ -7,14 +7,34 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 
+from .const import DOMAIN
+
 _LOGGER = logging.getLogger(__name__)
+
+# Detected via the Platform enum, not by importing
+# homeassistant.components.infrared directly - that import lazily pulls in
+# infrared-protocols, which isn't installed until the infrared component
+# itself is set up, so importing it eagerly would break fresh installs.
+INFRARED_PLATFORM_AVAILABLE = hasattr(Platform, "INFRARED")
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Tuya Remote Control from a config entry."""
     _LOGGER.debug("Setting up entry")
-    # Add the remote control entity
+
+    # Must finish before "infrared" below: the emitter entity needs the
+    # remote entity already registered in hass.data.
     await hass.config_entries.async_forward_entry_setups(entry, [Platform.REMOTE])
+
+    if INFRARED_PLATFORM_AVAILABLE:
+        # No Platform.INFRARED enum member on older cores, so forwarded by
+        # domain string instead. Isolated in its own try/except so a broken
+        # infrared setup (e.g. a requirements-install failure) can't take
+        # down the already-working remote entity.
+        try:
+            await hass.config_entries.async_forward_entry_setups(entry, ["infrared"])
+        except Exception:
+            _LOGGER.exception("Failed to set up the infrared emitter entity")
 
     # Register update listener for options flow
     entry.async_on_unload(entry.add_update_listener(update_listener))
@@ -24,7 +44,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
     _LOGGER.debug("Unloading")
-    return await hass.config_entries.async_unload_platforms(entry, Platform.REMOTE)
+    platforms = [Platform.REMOTE]
+    if INFRARED_PLATFORM_AVAILABLE:
+        platforms.append("infrared")
+    unloaded = await hass.config_entries.async_unload_platforms(entry, platforms)
+    if unloaded:
+        hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+    return unloaded
 
 async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
     """Handle options update."""

--- a/custom_components/localtuya_rc/infrared.py
+++ b/custom_components/localtuya_rc/infrared.py
@@ -1,0 +1,153 @@
+"""Expose the Tuya IR hub as an `infrared` adapter emitter entity.
+
+Lets brand device integrations (LG Infrared, Samsung Infrared, ...) send
+commands through this hub, alongside the existing `remote` entity. Only
+loaded on HA Core >= 2026.4 (see INFRARED_PLATFORM_AVAILABLE in __init__.py).
+"""
+import logging
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.event import (
+    async_track_entity_registry_updated_event,
+    async_track_state_change_event,
+)
+
+from homeassistant.components.infrared import InfraredCommand, InfraredEmitterEntity
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+# tinytuya's raw pulse encoder (Contrib.IRRemoteControlDevice.pulses_to_base64)
+# packs each duration as an unsigned 16-bit int.
+_MAX_PULSE_DURATION_US = 0xFFFF
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+    """Set up the infrared emitter entity for this Tuya IR hub config entry."""
+    remote_entity = hass.data.get(DOMAIN, {}).get(entry.entry_id, {}).get("remote_entity")
+    if remote_entity is None:
+        _LOGGER.debug(
+            "Remote entity for entry %s is not available (disabled, or failed"
+            " to set up); skipping infrared emitter setup",
+            entry.entry_id,
+        )
+        return
+
+    async_add_entities([TuyaIRInfraredEmitter(remote_entity)])
+
+
+def _timings_to_pulses(raw_timings):
+    """Convert infrared-protocols' signed timings to tinytuya's unsigned pulses.
+
+    tinytuya infers mark/space from position, not sign, so a leading space
+    is dropped and same-sign runs are merged before taking abs(). Clamped
+    to _MAX_PULSE_DURATION_US since some protocols' repeat-gaps (e.g. NEC's
+    ~96ms) overflow tinytuya's 16-bit encoding.
+
+    Raises HomeAssistantError if nothing is left to send.
+    """
+    merged = []
+    for timing in raw_timings:
+        if merged and (merged[-1] < 0) == (timing < 0):
+            merged[-1] += timing
+        else:
+            merged.append(timing)
+
+    # Merge first so a run of leading spaces collapses to at most one entry
+    # before it's dropped - otherwise a second leading space would land at
+    # an even (mark) index and invert the whole frame.
+    if merged and merged[0] < 0:
+        merged = merged[1:]
+    if not merged:
+        raise HomeAssistantError("Infrared command produced no timings to send")
+
+    return [min(abs(timing), _MAX_PULSE_DURATION_US) for timing in merged]
+
+
+class TuyaIRInfraredEmitter(InfraredEmitterEntity):
+    """Infrared emitter entity; delegates sends to the wrapped remote entity
+    to avoid opening a second connection to the same device."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, remote_entity):
+        super().__init__()
+        self._remote = remote_entity
+        self._last_available = None
+        self._remove_remote_listeners = ()
+
+    @property
+    def unique_id(self):
+        return f"{self._remote.unique_id}_ir_emitter"
+
+    @property
+    def available(self):
+        # self._remote.hass is None once the remote entity is removed/disabled.
+        return self._remote.hass is not None and self._remote.available
+
+    @property
+    def device_info(self):
+        return self._remote.device_info
+
+    async def async_added_to_hass(self):
+        """Subscribe to the wrapped remote entity's state to refresh availability."""
+        await super().async_added_to_hass()
+        if self._remote.entity_id:
+            self._last_available = self.available
+            self._subscribe_to_remote(self._remote.entity_id)
+        else:
+            _LOGGER.warning(
+                "Remote entity has no entity_id yet; %s will not track its availability",
+                self.entity_id,
+            )
+
+    def _subscribe_to_remote(self, entity_id):
+        """(Re-)subscribe to the remote entity's state and registry events.
+
+        Re-run on rename (see _handle_remote_entity_id_change) since
+        async_track_state_change_event filters on a fixed entity_id.
+        """
+        for unsub in self._remove_remote_listeners:
+            unsub()
+
+        unsub_state = async_track_state_change_event(
+            self.hass, [entity_id], self._handle_remote_state_change
+        )
+        unsub_registry = async_track_entity_registry_updated_event(
+            self.hass, entity_id, self._handle_remote_entity_id_change
+        )
+        self._remove_remote_listeners = (unsub_state, unsub_registry)
+        self.async_on_remove(unsub_state)
+        self.async_on_remove(unsub_registry)
+
+    @callback
+    def _handle_remote_state_change(self, event):
+        """Re-publish state when the remote entity's availability changes."""
+        available = self.available
+        if available != self._last_available:
+            self._last_available = available
+            self.async_write_ha_state()
+
+    @callback
+    def _handle_remote_entity_id_change(self, event):
+        new_entity_id = event.data.get("entity_id")
+        if new_entity_id:
+            self._subscribe_to_remote(new_entity_id)
+            self.async_write_ha_state()
+
+    async def async_send_command(self, command: InfraredCommand) -> None:
+        """Send an IR command through the wrapped remote entity."""
+        if not self.available:
+            raise HomeAssistantError("IR hub remote entity is unavailable")
+
+        try:
+            pulses = _timings_to_pulses(command.get_raw_timings())
+        except HomeAssistantError:
+            raise
+        except Exception as e:
+            raise HomeAssistantError(f"Invalid infrared command: {e}") from e
+
+        await self._remote.async_send_ir_pulses(pulses)

--- a/custom_components/localtuya_rc/manifest.json
+++ b/custom_components/localtuya_rc/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ClusterM/localtuya_rc/issues",
   "requirements": ["tinytuya>=1.20.0"],
-  "version": "2.0.0"
+  "version": "2.1.0"
 }

--- a/custom_components/localtuya_rc/remote.py
+++ b/custom_components/localtuya_rc/remote.py
@@ -419,6 +419,17 @@ class TuyaRC(RemoteEntity):
         await self.hass.async_add_executor_job(self._update_availibility)
         await self._async_load_storage_files()
 
+    async def async_send_ir_pulses(self, pulses):
+        """Send raw IR pulses (unsigned mark/space durations in µs, tinytuya format)
+        through this entity's connection, for infrared.py's emitter entity to reuse."""
+        try:
+            await self.hass.async_add_executor_job(self._send_button, pulses)
+        except HomeAssistantError:
+            raise
+        except Exception as e:
+            _LOGGER.error("Failed to send IR pulses via infrared platform, exception %s: %s", type(e), e, exc_info=True)
+            raise HomeAssistantError(str(e)) from e
+
     async def async_send_command(self, command, **kwargs):
         """Send a list of commands to a device."""
         device = kwargs.get(ATTR_DEVICE, None)

--- a/custom_components/localtuya_rc/remote.py
+++ b/custom_components/localtuya_rc/remote.py
@@ -256,8 +256,22 @@ class TuyaRC(RemoteEntity):
     def supported_features(self):
         return RemoteEntityFeature.LEARN_COMMAND | RemoteEntityFeature.DELETE_COMMAND
 
+    async def async_added_to_hass(self):
+        """Publish this entity into hass.data for infrared.py to find.
+
+        Only fires after a successful add, so a disabled entity (which never
+        reaches this hook) correctly leaves nothing for infrared.py to bind to.
+        """
+        await super().async_added_to_hass()
+        if self._entry is not None:
+            self.hass.data.setdefault(DOMAIN, {}).setdefault(self._entry.entry_id, {})["remote_entity"] = self
+
     async def async_will_remove_from_hass(self):
         _LOGGER.debug("Removing device %s from Home Assistant...", self._dev_id)
+        if self._entry is not None:
+            entry_data = self.hass.data.get(DOMAIN, {}).get(self._entry.entry_id, {})
+            if entry_data.get("remote_entity") is self:
+                del entry_data["remote_entity"]
         self._deinit()
 
     def _receive_button(self, timeout):

--- a/tests/test_infrared_platform.py
+++ b/tests/test_infrared_platform.py
@@ -1,0 +1,370 @@
+"""Tests for the infrared (adapter) platform.
+
+Stubs homeassistant.* like test_remote_recovery.py (no HA test harness here)
+and drives async entry points with asyncio.run() (CI has no pytest-asyncio).
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INFRARED_PATH = ROOT / "custom_components" / "localtuya_rc" / "infrared.py"
+PACKAGE_NAME = "localtuya_rc_infrared_test"
+
+
+def _install_module(monkeypatch, name, **attributes):
+    module = types.ModuleType(name)
+    module.__dict__.update(attributes)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+class _Unsub:
+    """Counting no-op unsub callable, so tests can assert an old
+    subscription was actually torn down before a new one is made."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+
+
+class FakeInfraredEmitterEntity:
+    """Stand-in for homeassistant.components.infrared.InfraredEmitterEntity."""
+
+    entity_id = None  # unset until the entity platform assigns it, like real Entity
+
+    def __init__(self):
+        self.hass = None
+        self._on_remove_callbacks = []
+        self.write_calls = 0
+
+    async def async_added_to_hass(self):
+        pass
+
+    def async_on_remove(self, callback_):
+        self._on_remove_callbacks.append(callback_)
+
+    def async_write_ha_state(self):
+        self.write_calls += 1
+
+
+class FakeRemote:
+    """Stand-in for the TuyaRC remote entity that infrared.py wraps."""
+
+    def __init__(self, unique_id="device-id", available=True, entity_id="remote.test", hass=object()):
+        self.unique_id = unique_id
+        self.available = available
+        self.entity_id = entity_id
+        self.hass = hass
+        self.device_info = {"identifiers": {("localtuya_rc", unique_id)}}
+        self.sent_pulses = None
+
+    async def async_send_ir_pulses(self, pulses):
+        self.sent_pulses = pulses
+
+
+class FakeCommand:
+    """Stand-in for infrared_protocols.commands.Command."""
+
+    def __init__(self, timings):
+        self._timings = timings
+
+    def get_raw_timings(self):
+        return list(self._timings)
+
+
+@pytest.fixture
+def infrared_module(monkeypatch):
+    homeassistant = _install_module(monkeypatch, "homeassistant")
+    homeassistant.__path__ = []
+    helpers = _install_module(monkeypatch, "homeassistant.helpers")
+    helpers.__path__ = []
+    components = _install_module(monkeypatch, "homeassistant.components")
+    components.__path__ = []
+
+    _install_module(
+        monkeypatch,
+        "homeassistant.core",
+        HomeAssistant=object,
+        callback=lambda func: func,
+    )
+    _install_module(monkeypatch, "homeassistant.config_entries", ConfigEntry=object)
+
+    class HomeAssistantError(Exception):
+        """Minimal Home Assistant error type for the unit under test."""
+
+    _install_module(
+        monkeypatch,
+        "homeassistant.exceptions",
+        HomeAssistantError=HomeAssistantError,
+    )
+
+    tracked_calls = []
+    state_unsubs = []
+    tracked_registry_calls = []
+    registry_unsubs = []
+
+    def _fake_track_state_change_event(hass, entity_ids, action):
+        tracked_calls.append((hass, entity_ids, action))
+        unsub = _Unsub()
+        state_unsubs.append(unsub)
+        return unsub
+
+    def _fake_track_entity_registry_updated_event(hass, entity_id, action):
+        tracked_registry_calls.append((hass, entity_id, action))
+        unsub = _Unsub()
+        registry_unsubs.append(unsub)
+        return unsub
+
+    _install_module(
+        monkeypatch,
+        "homeassistant.helpers.event",
+        async_track_state_change_event=_fake_track_state_change_event,
+        async_track_entity_registry_updated_event=_fake_track_entity_registry_updated_event,
+    )
+    _install_module(
+        monkeypatch,
+        "homeassistant.components.infrared",
+        InfraredCommand=FakeCommand,
+        InfraredEmitterEntity=FakeInfraredEmitterEntity,
+    )
+
+    package = _install_module(monkeypatch, PACKAGE_NAME)
+    package.__path__ = []
+    _install_module(monkeypatch, f"{PACKAGE_NAME}.const", DOMAIN="localtuya_rc")
+
+    spec = importlib.util.spec_from_file_location(
+        f"{PACKAGE_NAME}.infrared", INFRARED_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    module._tracked_calls = tracked_calls
+    module._state_unsubs = state_unsubs
+    module._tracked_registry_calls = tracked_registry_calls
+    module._registry_unsubs = registry_unsubs
+    return module
+
+
+# --- _timings_to_pulses (the signed -> unsigned conversion) ---
+
+
+def test_timings_abs_converts_signs(infrared_module):
+    assert infrared_module._timings_to_pulses([9000, -4500, 560, -1690, 560]) == [
+        9000,
+        4500,
+        560,
+        1690,
+        560,
+    ]
+
+
+def test_timings_drops_leading_space(infrared_module):
+    """A leading space has nothing to merge into and must be dropped."""
+    assert infrared_module._timings_to_pulses([-300, 9000, -4500]) == [9000, 4500]
+
+
+def test_timings_merges_consecutive_same_sign_entries(infrared_module):
+    """Position determines mark/space, so adjacent same-sign entries collapse."""
+    assert infrared_module._timings_to_pulses([100, 200, -50, -50, 300]) == [
+        300,
+        100,
+        300,
+    ]
+
+
+def test_timings_clamps_to_16_bit_unsigned_max(infrared_module):
+    """E.g. NEC's ~96ms repeat-gap exceeds tinytuya's 16-bit encoding."""
+    assert infrared_module._timings_to_pulses([9000, -96000]) == [
+        9000,
+        infrared_module._MAX_PULSE_DURATION_US,
+    ]
+
+
+def test_timings_drops_multiple_leading_spaces_without_inverting_frame(infrared_module):
+    """A run of leading spaces must merge into one before being dropped, or
+    the second space lands at an even (mark) index and inverts the frame."""
+    assert infrared_module._timings_to_pulses([-300, -200, 9000, -4500]) == [9000, 4500]
+
+
+def test_timings_raises_when_nothing_left_to_send(infrared_module):
+    with pytest.raises(infrared_module.HomeAssistantError):
+        infrared_module._timings_to_pulses([])
+
+    with pytest.raises(infrared_module.HomeAssistantError):
+        # A single leading space and nothing else.
+        infrared_module._timings_to_pulses([-500])
+
+    with pytest.raises(infrared_module.HomeAssistantError):
+        # All-space input merges into one leading space, then drops to empty.
+        infrared_module._timings_to_pulses([-100, -200])
+
+
+# --- TuyaIRInfraredEmitter ---
+
+
+def test_unique_id_is_derived_from_remote_and_distinct(infrared_module):
+    remote = FakeRemote(unique_id="device-id")
+    entity = infrared_module.TuyaIRInfraredEmitter(remote)
+
+    assert entity.unique_id == "device-id_ir_emitter"
+    assert entity.unique_id != remote.unique_id
+
+
+def test_available_mirrors_remote_availability(infrared_module):
+    remote = FakeRemote(available=False)
+    entity = infrared_module.TuyaIRInfraredEmitter(remote)
+    assert entity.available is False
+
+    remote.available = True
+    assert entity.available is True
+
+
+def test_available_is_false_when_remote_has_no_hass(infrared_module):
+    """A disabled/removed remote entity's hass becomes None."""
+    remote = FakeRemote(available=True, hass=None)
+    entity = infrared_module.TuyaIRInfraredEmitter(remote)
+
+    assert entity.available is False
+
+
+def test_device_info_delegates_to_remote(infrared_module):
+    remote = FakeRemote()
+    entity = infrared_module.TuyaIRInfraredEmitter(remote)
+    assert entity.device_info is remote.device_info
+
+
+def test_send_command_converts_signed_timings_to_unsigned_pulses(infrared_module):
+    remote = FakeRemote()
+    entity = infrared_module.TuyaIRInfraredEmitter(remote)
+    command = FakeCommand([9000, -4500, 560, -1690, 560])
+
+    asyncio.run(entity.async_send_command(command))
+
+    assert remote.sent_pulses == [9000, 4500, 560, 1690, 560]
+
+
+def test_send_command_raises_when_remote_unavailable(infrared_module):
+    remote = FakeRemote(available=False)
+    entity = infrared_module.TuyaIRInfraredEmitter(remote)
+    command = FakeCommand([9000, -4500])
+
+    with pytest.raises(infrared_module.HomeAssistantError):
+        asyncio.run(entity.async_send_command(command))
+
+    assert remote.sent_pulses is None
+
+
+def test_send_command_wraps_non_home_assistant_errors(infrared_module):
+    class BrokenCommand:
+        def get_raw_timings(self):
+            raise ValueError("malformed command")
+
+    remote = FakeRemote()
+    entity = infrared_module.TuyaIRInfraredEmitter(remote)
+
+    with pytest.raises(infrared_module.HomeAssistantError):
+        asyncio.run(entity.async_send_command(BrokenCommand()))
+
+    assert remote.sent_pulses is None
+
+
+def test_added_to_hass_subscribes_to_remote_entity_state(infrared_module):
+    remote = FakeRemote(entity_id="remote.living_room", available=True)
+    entity = infrared_module.TuyaIRInfraredEmitter(remote)
+    entity.hass = object()
+
+    asyncio.run(entity.async_added_to_hass())
+
+    assert len(infrared_module._tracked_calls) == 1
+    hass, entity_ids, action = infrared_module._tracked_calls[0]
+    assert entity_ids == ["remote.living_room"]
+
+    # Availability unchanged: must not write state on every poll cycle.
+    assert entity.write_calls == 0
+    action(None)
+    assert entity.write_calls == 0
+
+    # Availability actually changes: must write state exactly once.
+    remote.available = False
+    action(None)
+    assert entity.write_calls == 1
+    action(None)
+    assert entity.write_calls == 1
+
+
+def test_added_to_hass_skips_subscription_without_remote_entity_id(infrared_module):
+    remote = FakeRemote(entity_id=None)
+    entity = infrared_module.TuyaIRInfraredEmitter(remote)
+    entity.hass = object()
+
+    asyncio.run(entity.async_added_to_hass())
+
+    assert infrared_module._tracked_calls == []
+
+
+def test_added_to_hass_resubscribes_on_remote_entity_rename(infrared_module):
+    """async_track_state_change_event filters on a fixed entity_id, so a
+    rename of the wrapped remote entity must tear down the old subscription
+    and re-subscribe under the new entity_id, not go silently stale."""
+    remote = FakeRemote(entity_id="remote.old_id", available=True)
+    entity = infrared_module.TuyaIRInfraredEmitter(remote)
+    entity.hass = object()
+
+    asyncio.run(entity.async_added_to_hass())
+
+    assert len(infrared_module._tracked_registry_calls) == 1
+    _, watched_entity_id, registry_action = infrared_module._tracked_registry_calls[0]
+    assert watched_entity_id == "remote.old_id"
+    old_state_unsub = infrared_module._state_unsubs[0]
+    old_registry_unsub = infrared_module._registry_unsubs[0]
+
+    registry_action(types.SimpleNamespace(data={"entity_id": "remote.new_id"}))
+
+    assert old_state_unsub.calls == 1
+    assert old_registry_unsub.calls == 1
+    assert [entity_ids for _, entity_ids, _ in infrared_module._tracked_calls] == [
+        ["remote.old_id"],
+        ["remote.new_id"],
+    ]
+    assert [eid for _, eid, _ in infrared_module._tracked_registry_calls] == [
+        "remote.old_id",
+        "remote.new_id",
+    ]
+    assert entity.write_calls == 1
+
+
+# --- async_setup_entry wiring ---
+
+
+def test_setup_entry_adds_emitter_when_remote_entity_present(infrared_module):
+    remote = FakeRemote()
+    hass = types.SimpleNamespace(data={"localtuya_rc": {"entry-1": {"remote_entity": remote}}})
+    entry = types.SimpleNamespace(entry_id="entry-1")
+    added = []
+
+    asyncio.run(infrared_module.async_setup_entry(hass, entry, added.append))
+
+    assert len(added) == 1
+    (entities,) = added
+    assert len(entities) == 1
+    assert isinstance(entities[0], infrared_module.TuyaIRInfraredEmitter)
+    assert entities[0]._remote is remote
+
+
+def test_setup_entry_skips_when_remote_entity_missing(infrared_module):
+    hass = types.SimpleNamespace(data={})
+    entry = types.SimpleNamespace(entry_id="entry-1")
+    added = []
+
+    asyncio.run(infrared_module.async_setup_entry(hass, entry, added.append))
+
+    assert added == []

--- a/tests/test_init_platform_forwarding.py
+++ b/tests/test_init_platform_forwarding.py
@@ -1,0 +1,200 @@
+"""Tests for __init__.py's platform-forwarding order, INFRARED_PLATFORM_AVAILABLE
+detection, and unload/hass.data cleanup.
+
+Stubs homeassistant.* like test_remote_recovery.py (no HA test harness here)
+and drives async entry points with asyncio.run() (CI has no pytest-asyncio).
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INIT_PATH = ROOT / "custom_components" / "localtuya_rc" / "__init__.py"
+PACKAGE_NAME = "localtuya_rc_init_test"
+
+
+def _install_module(monkeypatch, name, **attributes):
+    module = types.ModuleType(name)
+    module.__dict__.update(attributes)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_init_module(monkeypatch, *, has_infrared_platform):
+    """Import __init__.py fresh, with Platform.INFRARED present or absent.
+
+    INFRARED_PLATFORM_AVAILABLE is computed once at import time, so each
+    scenario needs its own module instance rather than reusing a fixture.
+    """
+    homeassistant = _install_module(monkeypatch, "homeassistant")
+    homeassistant.__path__ = []
+    helpers = _install_module(monkeypatch, "homeassistant.helpers")
+    helpers.__path__ = []
+
+    _install_module(monkeypatch, "voluptuous")
+    _install_module(monkeypatch, "homeassistant.helpers.config_validation")
+    _install_module(monkeypatch, "homeassistant.core", HomeAssistant=object)
+    _install_module(monkeypatch, "homeassistant.config_entries", ConfigEntry=object)
+
+    platform_kwargs = {"REMOTE": "remote"}
+    if has_infrared_platform:
+        # Real HA's generated Platform enum gains INFRARED in the same
+        # release that ships homeassistant.components.infrared.
+        platform_kwargs["INFRARED"] = "infrared"
+    _install_module(
+        monkeypatch,
+        "homeassistant.const",
+        Platform=types.SimpleNamespace(**platform_kwargs),
+    )
+
+    package = _install_module(monkeypatch, PACKAGE_NAME)
+    package.__path__ = []
+    _install_module(monkeypatch, f"{PACKAGE_NAME}.const", DOMAIN="localtuya_rc")
+
+    spec = importlib.util.spec_from_file_location(f"{PACKAGE_NAME}.__init__", INIT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeConfigEntries:
+    def __init__(self, unload_result=True, fail_platforms=()):
+        self.forward_calls = []
+        self.unload_calls = []
+        self._unload_result = unload_result
+        self._fail_platforms = fail_platforms
+
+    async def async_forward_entry_setups(self, _entry, platforms):
+        self.forward_calls.append(list(platforms))
+        if any(p in self._fail_platforms for p in platforms):
+            raise RuntimeError("boom")
+
+    async def async_unload_platforms(self, _entry, platforms):
+        self.unload_calls.append(list(platforms))
+        return self._unload_result
+
+    async def async_reload(self, _entry_id):
+        pass
+
+
+class _FakeHass:
+    def __init__(self, unload_result=True, fail_platforms=()):
+        self.data = {}
+        self.config_entries = _FakeConfigEntries(
+            unload_result=unload_result, fail_platforms=fail_platforms
+        )
+
+
+class _FakeEntry:
+    def __init__(self, entry_id="entry-1"):
+        self.entry_id = entry_id
+        self.data = {}
+        self.options = {}
+
+    def async_on_unload(self, _func):
+        pass
+
+    def add_update_listener(self, _listener):
+        return lambda: None
+
+
+# --- feature detection ---
+
+
+def test_infrared_platform_available_true_when_platform_enum_has_infrared(monkeypatch):
+    module = _load_init_module(monkeypatch, has_infrared_platform=True)
+    assert module.INFRARED_PLATFORM_AVAILABLE is True
+
+
+def test_infrared_platform_available_false_when_platform_enum_lacks_infrared(monkeypatch):
+    module = _load_init_module(monkeypatch, has_infrared_platform=False)
+    assert module.INFRARED_PLATFORM_AVAILABLE is False
+
+
+# --- async_setup_entry forwarding ---
+
+
+def test_setup_entry_forwards_remote_then_infrared_separately_and_in_order(monkeypatch):
+    """Two separate awaited calls, not one combined list: infrared.py's
+    async_setup_entry looks up hass.data[...]["remote_entity"], which is
+    only populated once the "remote" platform's entities have actually been
+    added (see TuyaRC.async_added_to_hass in remote.py) - so "remote" must
+    be forwarded and fully finish before "infrared" is forwarded at all."""
+    module = _load_init_module(monkeypatch, has_infrared_platform=True)
+    hass = _FakeHass()
+    entry = _FakeEntry()
+
+    asyncio.run(module.async_setup_entry(hass, entry))
+
+    assert hass.config_entries.forward_calls == [
+        [module.Platform.REMOTE],
+        ["infrared"],
+    ]
+
+
+def test_setup_entry_survives_a_failed_infrared_forward(monkeypatch):
+    """A broken infrared setup (e.g. a requirements-install failure) must
+    not take down the config entry - "remote" already succeeded above it."""
+    module = _load_init_module(monkeypatch, has_infrared_platform=True)
+    hass = _FakeHass(fail_platforms=["infrared"])
+    entry = _FakeEntry()
+
+    result = asyncio.run(module.async_setup_entry(hass, entry))
+
+    assert result is True
+    assert hass.config_entries.forward_calls == [
+        [module.Platform.REMOTE],
+        ["infrared"],
+    ]
+
+
+def test_setup_entry_forwards_only_remote_when_infrared_unavailable(monkeypatch):
+    module = _load_init_module(monkeypatch, has_infrared_platform=False)
+    hass = _FakeHass()
+    entry = _FakeEntry()
+
+    asyncio.run(module.async_setup_entry(hass, entry))
+
+    assert hass.config_entries.forward_calls == [[module.Platform.REMOTE]]
+
+
+# --- async_unload_entry ---
+
+
+def test_unload_entry_unloads_both_platforms_and_pops_data_on_success(monkeypatch):
+    module = _load_init_module(monkeypatch, has_infrared_platform=True)
+    hass = _FakeHass(unload_result=True)
+    hass.data[module.DOMAIN] = {"entry-1": {"remote_entity": object()}}
+    entry = _FakeEntry()
+
+    result = asyncio.run(module.async_unload_entry(hass, entry))
+
+    assert result is True
+    assert hass.config_entries.unload_calls == [[module.Platform.REMOTE, "infrared"]]
+    assert "entry-1" not in hass.data[module.DOMAIN]
+
+
+def test_unload_entry_only_unloads_remote_when_infrared_unavailable(monkeypatch):
+    module = _load_init_module(monkeypatch, has_infrared_platform=False)
+    hass = _FakeHass(unload_result=True)
+    entry = _FakeEntry()
+
+    asyncio.run(module.async_unload_entry(hass, entry))
+
+    assert hass.config_entries.unload_calls == [[module.Platform.REMOTE]]
+
+
+def test_unload_entry_retains_hass_data_when_unload_fails(monkeypatch):
+    module = _load_init_module(monkeypatch, has_infrared_platform=True)
+    hass = _FakeHass(unload_result=False)
+    hass.data[module.DOMAIN] = {"entry-1": {"remote_entity": object()}}
+    entry = _FakeEntry()
+
+    result = asyncio.run(module.async_unload_entry(hass, entry))
+
+    assert result is False
+    assert "entry-1" in hass.data[module.DOMAIN]

--- a/tests/test_remote_infrared_integration.py
+++ b/tests/test_remote_infrared_integration.py
@@ -1,0 +1,253 @@
+"""Tests for remote.py's infrared-platform support: async_send_ir_pulses()
+and async_added_to_hass() publishing itself into hass.data.
+
+Stubs homeassistant.* like test_remote_recovery.py (no HA test harness here)
+and drives async entry points with asyncio.run() (CI has no pytest-asyncio).
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REMOTE_PATH = ROOT / "custom_components" / "localtuya_rc" / "remote.py"
+PACKAGE_NAME = "localtuya_rc_remote_infrared_test"
+
+
+class _PlatformSchema:
+    def extend(self, _schema):
+        return self
+
+
+class _FakeRemoteEntityBase:
+    """Stand-in for homeassistant.components.remote.RemoteEntity.
+
+    Only needs an async_added_to_hass() no-op: TuyaRC's own override calls
+    super().async_added_to_hass() before doing its own work.
+    """
+
+    async def async_added_to_hass(self):
+        pass
+
+
+def _install_module(monkeypatch, name, **attributes):
+    module = types.ModuleType(name)
+    module.__dict__.update(attributes)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+@pytest.fixture
+def remote_module(monkeypatch):
+    homeassistant = _install_module(monkeypatch, "homeassistant")
+    homeassistant.__path__ = []
+    helpers = _install_module(monkeypatch, "homeassistant.helpers")
+    helpers.__path__ = []
+    components = _install_module(monkeypatch, "homeassistant.components")
+    components.__path__ = []
+
+    _install_module(
+        monkeypatch,
+        "voluptuous",
+        Required=lambda value, **_kwargs: value,
+        In=lambda values: values,
+    )
+    _install_module(
+        monkeypatch,
+        "homeassistant.helpers.config_validation",
+        string=str,
+        boolean=bool,
+    )
+    _install_module(
+        monkeypatch,
+        "homeassistant.const",
+        CONF_NAME="name",
+        CONF_HOST="host",
+        CONF_DEVICE_ID="device_id",
+    )
+    _install_module(monkeypatch, "homeassistant.helpers.entity", DeviceInfo=dict)
+
+    class HomeAssistantError(Exception):
+        """Minimal Home Assistant error type for the unit under test."""
+
+    _install_module(
+        monkeypatch,
+        "homeassistant.exceptions",
+        HomeAssistantError=HomeAssistantError,
+    )
+    _install_module(
+        monkeypatch,
+        "homeassistant.components.persistent_notification",
+        async_create=lambda *_args, **_kwargs: None,
+    )
+    _install_module(
+        monkeypatch,
+        "homeassistant.components.remote",
+        ATTR_COMMAND_TYPE="command_type",
+        ATTR_TIMEOUT="timeout",
+        ATTR_ALTERNATIVE="alternative",
+        ATTR_COMMAND="command",
+        ATTR_DEVICE="device",
+        ATTR_DELAY_SECS="delay_secs",
+        ATTR_NUM_REPEATS="num_repeats",
+        ATTR_HOLD_SECS="hold_secs",
+        PLATFORM_SCHEMA=_PlatformSchema(),
+        RemoteEntity=_FakeRemoteEntityBase,
+        RemoteEntityFeature=types.SimpleNamespace(LEARN_COMMAND=1, DELETE_COMMAND=2),
+    )
+    _install_module(monkeypatch, "homeassistant.helpers.storage", Store=object)
+
+    contrib = types.SimpleNamespace(IRRemoteControlDevice=object)
+    tinytuya = _install_module(
+        monkeypatch, "tinytuya", Contrib=contrib, ERR_JSON=900, ERR_TIMEOUT=902
+    )
+    tinytuya.__path__ = []
+    _install_module(
+        monkeypatch,
+        "tinytuya.Contrib",
+        RFRemoteControlDevice=types.SimpleNamespace(RFRemoteControlDevice=object),
+    )
+
+    package = _install_module(monkeypatch, PACKAGE_NAME)
+    package.__path__ = []
+    _install_module(
+        monkeypatch,
+        f"{PACKAGE_NAME}.const",
+        DOMAIN="localtuya_rc",
+        DEFAULT_FRIENDLY_NAME="Tuya IR Remote Control",
+        CONF_LOCAL_KEY="local_key",
+        CONF_PROTOCOL_VERSION="protocol_version",
+        CONF_CONTROL_TYPE="control_type",
+        CONF_CLOUD_INFO="cloud_info",
+        CONF_PERSISTENT_CONNECTION="persistent_connection",
+        CODE_STORAGE_VERSION=1,
+        CODE_STORAGE_CODES="localtuya_rc_codes",
+        NOTIFICATION_TITLE="Tuya IR Remote Control",
+        DEFAULT_PERSISTENT_CONNECTION=False,
+    )
+    _install_module(
+        monkeypatch,
+        f"{PACKAGE_NAME}.rc_encoder",
+        rc_auto_encode=lambda value: value,
+        rc_auto_decode=lambda value, **_kwargs: value,
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        f"{PACKAGE_NAME}.remote", REMOTE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeHass:
+    def __init__(self):
+        self.data = {}
+
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
+
+
+def _make_remote(remote_module, entry=None):
+    remote = remote_module.TuyaRC(
+        "Test", "device-id", "127.0.0.1", "local-key", "3.3", control_type=1, entry=entry
+    )
+    remote.hass = _FakeHass()
+    return remote
+
+
+# --- async_send_ir_pulses ---
+
+
+def test_async_send_ir_pulses_calls_send_button_via_executor(remote_module):
+    remote = _make_remote(remote_module)
+    calls = []
+    remote._send_button = lambda pulses: calls.append(pulses)
+
+    asyncio.run(remote.async_send_ir_pulses([9000, 4500, 560]))
+
+    assert calls == [[9000, 4500, 560]]
+
+
+def test_async_send_ir_pulses_wraps_generic_exception_with_cause_preserved(remote_module):
+    remote = _make_remote(remote_module)
+    original = RuntimeError("boom")
+
+    def _boom(_pulses):
+        raise original
+
+    remote._send_button = _boom
+
+    with pytest.raises(remote_module.HomeAssistantError) as exc_info:
+        asyncio.run(remote.async_send_ir_pulses([1, 2]))
+
+    assert exc_info.value.__cause__ is original
+
+
+def test_async_send_ir_pulses_does_not_double_wrap_home_assistant_error(remote_module):
+    """_send_button() already raises a user-facing HomeAssistantError for the
+    failure modes it knows about; async_send_ir_pulses must propagate that
+    error as-is instead of wrapping it in a second, less specific one."""
+    remote = _make_remote(remote_module)
+    original = remote_module.HomeAssistantError("a specific, user-facing message")
+
+    def _boom(_pulses):
+        raise original
+
+    remote._send_button = _boom
+
+    with pytest.raises(remote_module.HomeAssistantError) as exc_info:
+        asyncio.run(remote.async_send_ir_pulses([1, 2]))
+
+    assert exc_info.value is original
+
+
+# --- async_added_to_hass publishing for infrared.py ---
+
+
+def test_async_added_to_hass_publishes_remote_entity_when_entry_present(remote_module):
+    entry = types.SimpleNamespace(entry_id="entry-1")
+    remote = _make_remote(remote_module, entry=entry)
+
+    asyncio.run(remote.async_added_to_hass())
+
+    assert remote.hass.data[remote_module.DOMAIN]["entry-1"]["remote_entity"] is remote
+
+
+def test_async_added_to_hass_does_not_publish_without_a_config_entry(remote_module):
+    """Legacy YAML platform setup (no config entry) has no infrared
+    counterpart to publish for; must not populate hass.data at all."""
+    remote = _make_remote(remote_module, entry=None)
+
+    asyncio.run(remote.async_added_to_hass())
+
+    assert remote.hass.data == {}
+
+
+def test_will_remove_from_hass_clears_own_hass_data_entry(remote_module):
+    entry = types.SimpleNamespace(entry_id="entry-1")
+    remote = _make_remote(remote_module, entry=entry)
+    asyncio.run(remote.async_added_to_hass())
+    assert remote.hass.data[remote_module.DOMAIN]["entry-1"]["remote_entity"] is remote
+
+    asyncio.run(remote.async_will_remove_from_hass())
+
+    assert "remote_entity" not in remote.hass.data[remote_module.DOMAIN]["entry-1"]
+
+
+def test_will_remove_from_hass_leaves_other_entitys_entry_alone(remote_module):
+    """A stale/replaced remote entity being torn down must not clobber a
+    different (newer) remote_entity already published for the same entry."""
+    entry = types.SimpleNamespace(entry_id="entry-1")
+    old_remote = _make_remote(remote_module, entry=entry)
+    old_remote.hass.data = {remote_module.DOMAIN: {"entry-1": {"remote_entity": "someone-else"}}}
+
+    asyncio.run(old_remote.async_will_remove_from_hass())
+
+    assert old_remote.hass.data[remote_module.DOMAIN]["entry-1"]["remote_entity"] == "someone-else"


### PR DESCRIPTION
Registers an `InfraredEmitterEntity` via Home Assistant's newer building-block `infrared` platform (HA Core >= 2026.4), alongside the existing `remote` entity. This lets brand-code integrations built on that architecture (LG Infrared, Samsung Infrared, …) use this hub as their emitter, instead of requiring users to maintain their own learned-code tables.

The new entity delegates transmission to the existing remote entity's tinytuya connection rather than opening a second one, and converts infrared-protocols' signed raw timings to tinytuya's unsigned pulse format. Availability is feature-detected at import time so older Home Assistant Core versions are unaffected and keep working with only the remote entity.

Closes #41